### PR TITLE
Add Sextant compatibility to the Sawtooth chart

### DIFF
--- a/charts/sawtooth/.helmignore
+++ b/charts/sawtooth/.helmignore
@@ -21,3 +21,4 @@
 .idea/
 *.tmproj
 .vscode/
+

--- a/charts/sawtooth/Chart.yaml
+++ b/charts/sawtooth/Chart.yaml
@@ -19,5 +19,5 @@ version: 0.1.12
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 1.1.5p1
-  
+
 

--- a/charts/sawtooth/sextant/details.yaml
+++ b/charts/sawtooth/sextant/details.yaml
@@ -25,4 +25,4 @@ buttonIcon: /thirdParty/hyperledger-sawtooth.png
 features: []
 
 # documentation pull down mark down 
-  
+

--- a/charts/sawtooth/sextant/form.js
+++ b/charts/sawtooth/sextant/form.js
@@ -396,3 +396,4 @@ const form = [
 ]
 
 module.exports = form
+

--- a/charts/sawtooth/sextant/options.js
+++ b/charts/sawtooth/sextant/options.js
@@ -48,3 +48,4 @@ module.exports = {
   peering,
   yesNo,
 }
+

--- a/charts/sawtooth/sextant/summary.js
+++ b/charts/sawtooth/sextant/summary.js
@@ -54,3 +54,6 @@ const summary = (values) => {
 }
 
 module.exports = summary
+
+
+

--- a/charts/sawtooth/templates/200-monitoring-svcs.yaml
+++ b/charts/sawtooth/templates/200-monitoring-svcs.yaml
@@ -31,3 +31,5 @@ spec:
   selector:
     app: {{ .Values.sawtooth.networkName }}-monitoring
 ---
+
+

--- a/charts/sawtooth/templates/201-monitoring-cm.yaml
+++ b/charts/sawtooth/templates/201-monitoring-cm.yaml
@@ -39,3 +39,4 @@ data:
     [[inputs.swap]]
     [[inputs.system]]
 ---
+

--- a/charts/sawtooth/templates/210-monitoring-set.yaml
+++ b/charts/sawtooth/templates/210-monitoring-set.yaml
@@ -65,3 +65,4 @@ spec:
           requests:
             cpu: "50m"
 ---
+

--- a/charts/sawtooth/templates/300-validator-roles.yaml
+++ b/charts/sawtooth/templates/300-validator-roles.yaml
@@ -54,3 +54,4 @@ subjects:
   name: {{ .Values.sawtooth.networkName }}-sa
   namespace: {{ .Values.sawtooth.namespace }}
 ---
+

--- a/charts/sawtooth/templates/310-validators-svcs.yaml
+++ b/charts/sawtooth/templates/310-validators-svcs.yaml
@@ -68,3 +68,4 @@ spec:
     app: {{ .Values.sawtooth.networkName }}-validator
 ---
 {{ end }}
+

--- a/charts/sawtooth/templates/320-validator-set.yaml
+++ b/charts/sawtooth/templates/320-validator-set.yaml
@@ -466,3 +466,4 @@ spec:
               - key: telegraf.conf
                 path: telegraf.conf
 ---
+

--- a/charts/sawtooth/templates/_helpers.tpl
+++ b/charts/sawtooth/templates/_helpers.tpl
@@ -61,3 +61,4 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+

--- a/charts/sawtooth/values.yaml
+++ b/charts/sawtooth/values.yaml
@@ -134,3 +134,4 @@ images:
   seth_rpc: blockchaintp/sawtooth-seth-rpc:BTP2.0
   seth_tp: blockchaintp/sawtooth-seth-tp:BTP2.0
   xo_demo: blockchaintp/xo-demo:BTP2.0
+


### PR DESCRIPTION
Adds a /sextant directory to the sawtooth chart which contains the additional information that Sextant needs to render the deployment options and form. 