### PR TITLE
ci: only update readmes on master branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -201,11 +201,13 @@ def updateReadmes(branch) {
                                     usernameVariable: 'GIT_USERNAME')]) {
     withEnv(["branch=${branch}"]) {
       sh '''
-        diff_readmes=$(git diff --name-only |grep README.md|wc -l)
-        if [ "$diff_readmes" -gt 0 ]; then
-          git add charts/*/README.md
-          git commit -m "ci: Updating README.md files"
-          git push origin HEAD:${branch}
+        if [ "$branch" = "master" ]; then
+          diff_readmes=$(git diff --name-only |grep README.md|wc -l)
+          if [ "$diff_readmes" -gt 0 ]; then
+            git add charts/*/README.md
+            git commit -m "ci: Updating README.md files"
+            git push origin HEAD:${branch}
+          fi
         fi
       '''
     }


### PR DESCRIPTION
Otherwise we end up with som random PR-* branches showing up.

Signed-off-by: Kevin O'Donnell <kevin@blockchaintp.com>