### PR TITLE
feat(daml-on-besu): add annotations option

### DIFF
--- a/charts/daml-on-besu/Chart.yaml
+++ b/charts/daml-on-besu/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.0.35
+version: 0.0.36
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.

--- a/charts/daml-on-besu/templates/besu-statefulset.yaml
+++ b/charts/daml-on-besu/templates/besu-statefulset.yaml
@@ -26,6 +26,9 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9545"
         prometheus.io/path: "/metrics"
+        {{- if .Values.besu.annotations }}
+        {{- toYaml .Values.besu.annotations | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "besu.serviceAccountName" . }}
       affinity:

--- a/charts/daml-on-besu/templates/daml-statefulset.yaml
+++ b/charts/daml-on-besu/templates/daml-statefulset.yaml
@@ -15,6 +15,10 @@ spec:
     metadata:
       labels:
 {{ include "daml.labels" .| indent 8}}
+      {{- if .Values.daml.annotations }}
+      annotations:
+        {{- toYaml .Values.daml.annotations | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "besu.serviceAccountName" . }}
       containers:

--- a/charts/daml-on-besu/values.yaml
+++ b/charts/daml-on-besu/values.yaml
@@ -35,6 +35,8 @@ besu:
     storageClass: "gp2"
     size: "40Gi"
   resources: {}
+  ## @md | `besu.annotations` | annotations for the besu statefulset | map | null |
+  annotations: {}
   serviceAccount:
     create: true
     name:
@@ -133,6 +135,8 @@ daml:
     repository: dev.catenasys.com:8084/blockchaintp/rpc
     tag: BTP2.1.0rc14
     imagePullPolicy: IfNotPresent
+  ## @md | `daml.annotations` | annotations for the daml rpc statefulset | map | null |
+  annotations: {}
   ## @md | `daml.rpcCount` | number identical rpc participants to allocate | number | 1 |
   rpcCount: 1
   ## @md | `daml.rpc` | settings for daml-rpc | map | N/A |


### PR DESCRIPTION
Adds the ability to optionally set custom annotations for both the besu and daml-rpc statefulsets from the values.yaml file.
SXT-632