### PR TITLE
Set the key in an existing postgres password

### DIFF
--- a/charts/sextant/Chart.yaml
+++ b/charts/sextant/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.8
+version: 2.1.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/sextant/templates/statefulset.yaml
+++ b/charts/sextant/templates/statefulset.yaml
@@ -69,7 +69,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{.Values.postgres.existingPasswordSecret}}
-                  key: password
+                  key: {{.Values.postgres.existingPasswordSecretKey}}
               {{- else }}
               value: {{ .Values.postgres.password }}
               {{- end }}

--- a/charts/sextant/values.yaml
+++ b/charts/sextant/values.yaml
@@ -90,6 +90,8 @@ postgres:
   password: postgres
   ## @md | `postgres.existingPasswordSecret` | name of a secret containing the postgres password | string | nil |
   existingPasswordSecret:
+  ## @md | `postgres.existingPasswordSecret` | name of the key in a secret containing the postgres password | string | password |
+  existingPasswordSecretKey: password
   ## @md | `postgres.tls` | postgres TLS configuration | string | nil |
   tls:
   ## @md | `postgres.persistence` | postgres persistence settings | map | N/A |


### PR DESCRIPTION
This enables setting the key in an existing postrgess secret from the values.yaml file. It defaults to `password` which was the previous hardcoded value.