### PR TITLE
feat(standard-defs): lib.ingress can now support old style values

### DIFF
--- a/charts/standard-defs/templates/_ingress.tpl
+++ b/charts/standard-defs/templates/_ingress.tpl
@@ -65,6 +65,27 @@ spec:
             {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" $serviceName "servicePort" $servicePort "context" $ctx) | nindent 14 }}
     {{- end }}
+    {{/* .ingress.hosts is deprecated */}}
+    {{- range .ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- if .path }}
+          - path: {{ default "/" .path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" $ctx) }}
+            pathType: {{ default "ImplementationSpecific" .pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" $serviceName "servicePort" $servicePort "context" $ctx) | nindent 14 }}
+          {{- end }}
+          {{- range .paths }}
+          - path: {{ . | quote }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" $ctx) }}
+            pathType: ImplementationSpecific
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" $serviceName "servicePort" $servicePort "context" $ctx) | nindent 14 }}
+          {{- end }}
+    {{- end }}
+    {{/* .ingress.hosts is deprecated */}}
   {{- if or .ingress.tls .ingress.extraTls }}
   tls:
     {{- if .ingress.tls }}


### PR DESCRIPTION
Old style ingress value declarations use a .hosts list, but the new ones have a primary and .extraHosts path. 

This PR makes the new style ingress templates support the old style .hosts declaration

Signed-off-by: Kevin O'Donnell <kevin@blockchaintp.com>