### PR TITLE
fix(default-data): ensure we are not asking to map over a nil array

### DIFF
--- a/charts/daml-on-sawtooth/sextant/summary.js
+++ b/charts/daml-on-sawtooth/sextant/summary.js
@@ -30,10 +30,10 @@ const summary = (values) => {
     value: getConsensusTitle(sawtooth.consensus),
   }, {
     title: 'External Seeds',
-    value: sawtooth.externalSeeds.map((seed) => seed.address),
+    value: (sawtooth.externalSeeds || []).map((seed) => seed.address),
   }, {
     title: 'Custom Transaction Processors',
-    value: sawtooth.customTPs.map((tp) => `${tp.name} (${tp.image})`),
+    value: (sawtooth.customTPs || []).map((tp) => `${tp.name} (${tp.image})`),
   }, {
     title: 'Sawtooth Validator Port',
     value: '8800',

--- a/charts/sawtooth/sextant/summary.js
+++ b/charts/sawtooth/sextant/summary.js
@@ -30,13 +30,13 @@ const summary = (values) => {
     value: getConsensusTitle(sawtooth.consensus),
   }, {
     title: 'External Seeds',
-    value: sawtooth.externalSeeds.map((seed) => seed.ip),
+    value: (sawtooth.externalSeeds || []).map((seed) => seed.ip),
   }, {
     title: 'Sawtooth Validator Port',
     value: '8800',
   }, {
     title: 'Custom Transaction Processors',
-    value: sawtooth.customTPs.map((tp) => `${tp.name} (${tp.image})`),
+    value: (sawtooth.customTPs || []).map((tp) => `${tp.name} (${tp.image})`),
   }]
 }
 

--- a/charts/tfs-on-sawtooth/sextant/summary.js
+++ b/charts/tfs-on-sawtooth/sextant/summary.js
@@ -27,13 +27,13 @@ const summary = (values) => {
     value: getConsensusTitle(sawtooth.sawtooth.consensus),
   }, {
     title: 'External Seeds',
-    value: sawtooth.sawtooth.externalSeeds.map((seed) => seed.ip),
+    value: (sawtooth.sawtooth.externalSeeds || []).map((seed) => seed.ip),
   }, {
     title: 'Sawtooth Validator Port',
     value: '8800',
   }, {
     title: 'Custom Transaction Processors',
-    value: sawtooth.sawtooth.customTPs.map((tp) => `${tp.name} (${tp.image})`),
+    value: (sawtooth.sawtooth.customTPs || []).map((tp) => `${tp.name} (${tp.image})`),
   }]
 }
 


### PR DESCRIPTION
We were trying to loop over an undefined array of custom tps for the sextant summary - this PR ensures it doesn't blow up in case the array is `undefined`

Signed-off-by: Kai Davenport <kaiyadavenport@gmail.com>