### PR TITLE
fix: on jobs correct hook delete-policy

### DIFF
--- a/charts/daml-on-besu/templates/cert-job.yaml
+++ b/charts/daml-on-besu/templates/cert-job.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
 {{ include "besu.labels" . | indent 4 }}
   annotations:
-    helm.sh/hook-delete-policy: "hook-succeeded"
+    helm.sh/hook: post-install
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: hook-succeeded
 spec:
   backoffLimit: 3
   completions: 1

--- a/charts/daml-on-postgres/templates/cert-job.yaml
+++ b/charts/daml-on-postgres/templates/cert-job.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
 {{ include "daml.labels" . | indent 4 }}
   annotations:
-    helm.sh/hook-delete-policy: "hook-succeeded"
+    helm.sh/hook: post-install
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: hook-succeeded
 spec:
   backoffLimit: 3
   completions: 1

--- a/charts/daml-on-qldb/templates/cert-job.yaml
+++ b/charts/daml-on-qldb/templates/cert-job.yaml
@@ -7,7 +7,9 @@ metadata:
     app: {{.Values.deployment.name}}-validator
     daml: {{.Values.deployment.name}}-daml-rpc
   annotations:
-    helm.sh/hook-delete-policy: "hook-succeeded"
+    helm.sh/hook: post-install
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: hook-succeeded
 spec:
   backoffLimit: 3
   completions: 1

--- a/charts/daml-on-sawtooth/templates/cert-job.yaml
+++ b/charts/daml-on-sawtooth/templates/cert-job.yaml
@@ -7,7 +7,9 @@ metadata:
     app: {{.Values.sawtooth.networkName}}-daml-rpc
     daml: {{.Values.sawtooth.networkName}}-daml-rpc
   annotations:
-    helm.sh/hook-delete-policy: "hook-succeeded"
+    helm.sh/hook: post-install
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: hook-succeeded
 spec:
   backoffLimit: 3
   completions: 1

--- a/charts/orion/templates/keygen-job.yaml
+++ b/charts/orion/templates/keygen-job.yaml
@@ -9,7 +9,9 @@ metadata:
   labels:
 {{ include "common.labels" . | indent 4 }}
   annotations:
-    helm.sh/hook-delete-policy: "hook-succeeded"
+    helm.sh/hook: post-install
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: hook-succeeded
 spec:
   backoffLimit: 3
   completions: 1


### PR DESCRIPTION
fix(daml-on-besu): correct hook delete-policy
fix(orion): correct hook delete-policy
fix(daml-on-postgres) correct hook delete-policy
fix(daml-on-qldb): correct hook delete-policy
fix(daml-on-sawtooth): correct hook delete-policy

Signed-off-by: Kevin O'Donnell <kevin@blockchaintp.com>