### PR TITLE
fix(sextant): correct the label used to find the pod name in portforward instructions

### DIFF
--- a/charts/sextant/Chart.yaml
+++ b/charts/sextant/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.16
+version: 2.1.17
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/sextant/templates/NOTES.txt
+++ b/charts/sextant/templates/NOTES.txt
@@ -21,7 +21,7 @@
   export SERVICE_IP=$(kubectl get svc {{ template "common.names.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods -l "app={{ template "common.names.name" . }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods -l "app.kubernetes.io/name={{ template "common.names.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl port-forward $POD_NAME 8080:80
 {{- end }}


### PR DESCRIPTION
Corrects the label used in the NOTES.txt file to give portforward instructions 