### PR TITLE
adds option to create a dockerconfigjson secret to the helm chart

### DIFF
--- a/charts/sextant/Chart.yaml
+++ b/charts/sextant/Chart.yaml
@@ -18,7 +18,7 @@ version: 2.2.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.1.7
+appVersion: 2.1.8
 
 dependencies:
   - name: standard-defs

--- a/charts/sextant/app-readme.md
+++ b/charts/sextant/app-readme.md
@@ -1,0 +1,4 @@
+# Sextant
+
+Sextant automates the deployment and management of enterprise blockchain infrastructure.
+Find out more at docs.blockchaintp.com

--- a/charts/sextant/questions.yaml
+++ b/charts/sextant/questions.yaml
@@ -1,0 +1,19 @@
+questions:
+- variable: imagePullSecrets.createSecret.registryUser
+  default: ""
+  required: true
+  type: string
+  label: Your Registry Username from BTP
+  group: "Registry Settings"
+- variable: imagePullSecrets.createSecret.registryPassword
+  default: ""
+  required: true
+  type: password
+  label: Your Registry Password from BTP
+  group: "Registry Settings"
+- variable: imagePullSecrets.createSecret.registryURL
+  default: "dev.catenasys.com:8083"
+  required: true
+  type: string
+  label: Registry URL
+  group: "Registry Settings"

--- a/charts/sextant/templates/_helpers.tpl
+++ b/charts/sextant/templates/_helpers.tpl
@@ -90,3 +90,7 @@ Local alternative of lib.image.url until the correct version is stable
 image: {{ include "override.lib.image.url" . }}
 imagePullPolicy: {{ default "IfNotPresent" .imageRoot.pullPolicy }}
 {{- end -}}
+
+{{- define "dockerconfigjson" }}
+{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.imagePullSecrets.createSecret.registryUrl (printf "%s:%s" .Values.imagePullSecrets.createSecret.registryUser .Values.imagePullSecrets.createSecret.registryPassword | b64enc) | b64enc }}
+{{- end }}

--- a/charts/sextant/templates/regsecret.yaml
+++ b/charts/sextant/templates/regsecret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.imagePullSecrets.createSecret.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "common.names.fullname" . }}-btp-lic
+  labels: {{- include "lib.labels" . | nindent 4 }}
+    component: sextant
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "dockerconfigjson" . }}
+{{- end }}

--- a/charts/sextant/templates/serviceaccount.yaml
+++ b/charts/sextant/templates/serviceaccount.yaml
@@ -5,8 +5,11 @@ kind: ServiceAccount
 metadata:
   name: {{ include "lib.serviceAccountName" . }}
   namespace: {{.Release.Namespace}}
-{{- if .Values.imagePullSecrets.enabled }}
+{{- if or .Values.imagePullSecrets.enabled .Values.imagePullSecrets.createSecret.enabled }}
 imagePullSecrets:
+{{- if.Values.imagePullSecrets.createSecret.enabled }}
+  - name: {{ template "common.names.fullname" . }}-btp-lic
+{{- end }}
 {{- range .Values.imagePullSecrets.value }}
   - name: {{ .name }}
 {{- end }}

--- a/charts/sextant/values.yaml
+++ b/charts/sextant/values.yaml
@@ -62,8 +62,18 @@ deployment:
 imagePullSecrets:
   ## @md | `imagePullSecrets.enabled` | true if imagePullSecrets are required | boolean | false |
   enabled: false
-  ## @md | `imagePullSecrets.value` | a list if named secret references of the form   ```- name: secretName```| list | [] |
+  ## @md | `imagePullSecrets.value` | a list of named secret references of the form   ```- name: secretName```| list | [] |
   value: []
+
+  createSecret:
+    ## @md | `imagePullSecrets.createSecret.enabled` | true to create a image pull secret | boolean | false |
+    enabled: false
+    ## @md | `imagePullSecrets.createSecret.registryUrl` | the registry url | string | nil |
+    registryUrl:
+    ## @md | `imagePullSecrets.createSecret.registryUser` | the username for the registry | string | nil |
+    registryUser:
+    ## @md | `imagePullSecrets.createSecret.registryPassword` | the password for the registry | string | nil |
+    registryPassword:
 
 ## @md | `replicaCount` | number of Sextant replicas to run | int | 1 |
 replicaCount: 1


### PR DESCRIPTION
Adds the option create a dockerconfigjson secret specifying the credentials in the values.yaml. This is required for the Rancher Marketplace so that users can enter their Nexus credentials in a web form in Rancher, and the secret is created from them. 