### PR TITLE
Add namespace to help notes in Sextant chart

### DIFF
--- a/charts/sextant/Chart.yaml
+++ b/charts/sextant/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.17
+version: 2.1.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/sextant/templates/NOTES.txt
+++ b/charts/sextant/templates/NOTES.txt
@@ -2,7 +2,7 @@
 
 
 1. Get the initial Sextant application username and password by running this command
-  kubectl describe pod/{{ template "common.names.fullname" .}}-0|grep INITIAL_
+  kubectl describe pod/{{ template "common.names.fullname" .}}-0 --namespace {{ .Release.Namespace }} | grep INITIAL_
 
 2. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}


### PR DESCRIPTION
Adds the namespace of the installed sextant release the kubectl describe command that is used to get the initial password. This is needed for the integration testing makefile which runs this kubectl command, and the helm chart seemed like the best place add it. 
sxt859