### PR TITLE
fix(sextant): set NODE_ENV to development on edition enterprise

### DIFF
--- a/charts/sextant/Chart.yaml
+++ b/charts/sextant/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.2.5
+version: 2.2.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/sextant/templates/statefulset.yaml
+++ b/charts/sextant/templates/statefulset.yaml
@@ -79,6 +79,10 @@ spec:
             - name: POSTGRES_TLS
               value: {{ .Values.postgres.tls | quote }}
             {{- end }}
+            {{- if eq .Values.edition "enterprise" -}}
+            - name: NODE_ENV
+              value: "development"
+            {{- end -}}
             {{- include "lib.safeToYaml" .Values.api.env | nindent 12 }}
           volumeMounts:
             {{- include "lib.volumeMounts" .Values.extraVolumeMounts | nindent 12 }}


### PR DESCRIPTION
Signed-off-by: Kevin O'Donnell <kevin@blockchaintp.com>
