### PR TITLE
feat(sextant): remove default value for postgres persistence storage class

### DIFF
--- a/charts/sextant/Chart.yaml
+++ b/charts/sextant/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.2.13
+version: 2.2.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/sextant/values.yaml
+++ b/charts/sextant/values.yaml
@@ -195,8 +195,8 @@ postgres:
     ## @md | `postgres.persistence.accessModes` | postgres PVC access modes | list | [ "ReadWriteOnce" ] |
     accessModes:
       - "ReadWriteOnce"
-    ## @md | `postgres.persistence.storageClass` | postgres PVC storageClass | string | "gp2" |
-    storageClass: "gp2"
+    ## @md | `postgres.persistence.storageClass` | postgres PVC storageClass | string | nil |
+    storageClass: ""
     ## @md | `postgres.persistence.size` | postgres PVC volume size | string | "40Gi" |
     size: "40Gi"
   ## @md | `postgres.resources` | UI resources | map | nil |


### PR DESCRIPTION
Removes the default value of "gp2" for the postgres persistence storage class. This means that if left unchanged the clusters default storage class will be used. 