### PR TITLE
fix(sextant): update kubeVersion to >=1.19-0

### DIFF
--- a/charts/sextant/Chart.yaml
+++ b/charts/sextant/Chart.yaml
@@ -7,11 +7,11 @@ home: https://www.blockchaintp.com/sextant
 # to be deployed.
 type: application
 
-kubeVersion: ">= 1.19"
+kubeVersion: ">=1.19-0"
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.2.15
+version: 2.2.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.


### PR DESCRIPTION
Updates the kubeVersion in the Sextant chart to >=1.19-0 from >=1.19. This seems to let versions like v1.21.5-eks-bc4871b pass which where previously failing 