### PR TITLE
fix(chronicle): port chronicle chart updates from CHRON-402 - BREAKING CHANGES

### DIFF
--- a/charts/chronicle/Chart.yaml
+++ b/charts/chronicle/Chart.yaml
@@ -17,7 +17,7 @@ keywords:
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.1.16
+version: 0.1.17
 
 # This is the version number of Chronicle being deployed. This version
 # number should be incremented each time you make changes to Chronicle.

--- a/charts/chronicle/templates/chronicle-init.yaml
+++ b/charts/chronicle/templates/chronicle-init.yaml
@@ -159,13 +159,16 @@ spec:
           command: [ "bash", "-ec"]
           args:
             - |
-              if opactl \
-                  --sawtooth-address tcp://$HOST:$PORT \
-                    get-policy \
-                      --id {{ .Values.opa.policy.id }} \
-                      --output policy.bin >/dev/null 2>&1; then
+              echo "Attempting to get policy."
+              opactl \
+                --sawtooth-address tcp://$HOST:$PORT \
+                  get-policy \
+                    --id {{ .Values.opa.policy.id }} \
+                    --output /shared-data/policy.bin
+              if [ -f "/shared-data/policy.bin" ]; then
                 echo "Policy already set."
                 touch /shared-data/policy-already-set
+                exit 0
               else
                 echo "Policy not found."
                 exit 0


### PR DESCRIPTION
# BREAKING CHANGE:  Init Job get-policy step requires a 0.7.4 Chronicle release

## To-do
- [ ] fix incrementing chart version

[CHRON-403](https://blockchaintp.atlassian.net/browse/CHRON-403)

# PR Checklist

## Please complete this checklist after opening your PR

* [x] I have updated documentation as necessary
* [x] I have updated helm chart(s) if needed
* [x] I have added tests if needed
* [x] All new and existing tests are passing
* [x] Any breaking changes are clearly flagged and documented
* [x] I’ve included a link to any relevant ticket(s)


[CHRON-403]: https://blockchaintp.atlassian.net/browse/CHRON-403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ