### PR TITLE
fix(chronicle): add api-test support for third-party auth services

### DIFF
--- a/charts/chronicle-on-sawtooth/Chart.yaml
+++ b/charts/chronicle-on-sawtooth/Chart.yaml
@@ -17,7 +17,7 @@ keywords:
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.1.18
+version: 0.1.19
 
 # This is the version number of Chronicle being deployed. This version
 # number should be incremented each time you make changes to Chronicle.

--- a/charts/chronicle-on-sawtooth/templates/test-token-getter-roles.yaml
+++ b/charts/chronicle-on-sawtooth/templates/test-token-getter-roles.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.test.enabled }}
+{{- if .Values.test.api.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/chronicle-on-sawtooth/templates/tests/api-test.yaml
+++ b/charts/chronicle-on-sawtooth/templates/tests/api-test.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.test.enabled }}
+{{- if .Values.test.api.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -16,8 +16,9 @@ spec:
       serviceAccountName:  {{ include "lib.serviceAccountName" . }}
       automountServiceAccountToken: true
       {{- if .Values.auth.required }}
+      {{ if not .Values.test.auth.token }}
       {{ if not .Values.devIdProvider.enabled }}
-      {{ required "If 'auth.required' when using the test suite 'devIdProvider.enabled' must be set to 'true'!" .Values.devIdProvider.enabled }}
+      {{ required "If 'auth.required' when using the api-test 'test.auth.token' must be provided or 'devIdProvider.enabled' must be set to 'true'!" .Values.devIdProvider.enabled }}
       {{ end }}
       initContainers:
         - name: wait-for-id-provider
@@ -73,6 +74,7 @@ spec:
           volumeMounts:
             - name: shared-data
               mountPath: /shared-data
+      {{ end }}
       {{- end }}
       containers:
         - name: test
@@ -80,12 +82,24 @@ spec:
           command: [ "sh", "-ec" ]
           args:
             - |
+              {{ if not .Values.test.auth.token }}
+              {{ if or .Values.auth.jwks.url .Values.auth.userinfo.url }}
+              echo "Auth endpoints provided but no token provided."
+              echo "Please provide 'test.auth.token' in the values.yaml file."
+              exit 1
+              {{ end }}
+              {{ end }}
+
               API={{ include "chronicle.api.service" . }}
               export PORT={{ .Values.port }}
               echo "Waiting for API to be ready ..."
               wait-for-it $API:$PORT --timeout=0
               echo "Getting IP address for API ..."
               getent hosts $API | cut -f 1 -d \ | head -n 1 > /shared-data/api-ip || exit 1
+
+              {{- if .Values.test.auth.token }}
+              echo "{{ .Values.test.auth.token }}" > /shared-data/jwks-token
+              {{- end }}
 
               if [ -f "/shared-data/jwks-token" ]; then
                 echo "Found token."

--- a/charts/chronicle-on-sawtooth/values.yaml
+++ b/charts/chronicle-on-sawtooth/values.yaml
@@ -133,7 +133,9 @@ serviceAccount:
 test:
   ## @md | `test.api` | test the chronicle GraphQL server API |
   api:
-    ## @md | `api-test-container.image` | the image to use for the api-test container | blockchaintp/chronicle-api-test |
+    ## @md | `test.api.enabled` | true to enable api-test Jobs and Services | true |
+    enabled: true
+    ## @md | `test.api.image` | the image to use for the api-test container | blockchaintp/chronicle-helm-api-test |
     image:
       ## @md | `test.api.image.pullPolicy` | the image pull policy | IfNotPresent |
       pullPolicy: IfNotPresent
@@ -141,8 +143,9 @@ test:
       repository: blockchaintp/chronicle-helm-api-test-amd64
       ## @md | `test.api.image.tag` | the image tag | latest |
       tag: BTP2.1.0-0.7.3
-  ## @md | `test.enabled` | true to enable test Jobs and Services | true |
-  enabled: true
+  auth:
+    ## @md | `test.auth.token` | provide a token for auth-related testing | nil |
+    token:
 
 postgres:
   # if enabled we allocate a postgres database here

--- a/charts/chronicle/Chart.yaml
+++ b/charts/chronicle/Chart.yaml
@@ -17,7 +17,7 @@ keywords:
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.1.18
+version: 0.1.19
 
 # This is the version number of Chronicle being deployed. This version
 # number should be incremented each time you make changes to Chronicle.

--- a/charts/chronicle/templates/test-token-getter-roles.yaml
+++ b/charts/chronicle/templates/test-token-getter-roles.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.test.enabled }}
+{{- if .Values.test.api.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/chronicle/templates/tests/api-test.yaml
+++ b/charts/chronicle/templates/tests/api-test.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.test.enabled }}
+{{- if .Values.test.api.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -16,8 +16,9 @@ spec:
       serviceAccountName:  {{ include "lib.serviceAccountName" . }}
       automountServiceAccountToken: true
       {{- if .Values.auth.required }}
+      {{ if not .Values.test.auth.token }}
       {{ if not .Values.devIdProvider.enabled }}
-      {{ required "If 'auth.required' when using the test suite 'devIdProvider.enabled' must be set to 'true'!" .Values.devIdProvider.enabled }}
+      {{ required "If 'auth.required' when using the api-test 'test.auth.token' must be provided or 'devIdProvider.enabled' must be set to 'true'!" .Values.devIdProvider.enabled }}
       {{ end }}
       initContainers:
         - name: wait-for-id-provider
@@ -73,6 +74,7 @@ spec:
           volumeMounts:
             - name: shared-data
               mountPath: /shared-data
+      {{ end }}
       {{- end }}
       containers:
         - name: test
@@ -80,12 +82,24 @@ spec:
           command: [ "sh", "-ec" ]
           args:
             - |
+              {{ if not .Values.test.auth.token }}
+              {{ if or .Values.auth.jwks.url .Values.auth.userinfo.url }}
+              echo "Auth endpoints provided but no token provided."
+              echo "Please provide 'test.auth.token' in the values.yaml file."
+              exit 1
+              {{ end }}
+              {{ end }}
+
               API={{ include "chronicle.api.service" . }}
               export PORT={{ .Values.port }}
               echo "Waiting for API to be ready ..."
               wait-for-it $API:$PORT --timeout=0
               echo "Getting IP address for API ..."
               getent hosts $API | cut -f 1 -d \ | head -n 1 > /shared-data/api-ip || exit 1
+
+              {{- if .Values.test.auth.token }}
+              echo "{{ .Values.test.auth.token }}" > /shared-data/jwks-token
+              {{- end }}
 
               if [ -f "/shared-data/jwks-token" ]; then
                 echo "Found token."

--- a/charts/chronicle/values.yaml
+++ b/charts/chronicle/values.yaml
@@ -133,7 +133,9 @@ serviceAccount:
 test:
   ## @md | `test.api` | test the chronicle GraphQL server API |
   api:
-    ## @md | `api-test-container.image` | the image to use for the api-test container | blockchaintp/chronicle-api-test |
+    ## @md | `test.api.enabled` | true to enable api-test Jobs and Services | true |
+    enabled: true
+    ## @md | `test.api.image` | the image to use for the api-test container | blockchaintp/chronicle-helm-api-test |
     image:
       ## @md | `test.api.image.pullPolicy` | the image pull policy | IfNotPresent |
       pullPolicy: IfNotPresent
@@ -141,8 +143,9 @@ test:
       repository: blockchaintp/chronicle-helm-api-test-amd64
       ## @md | `test.api.image.tag` | the image tag | latest |
       tag: BTP2.1.0-0.7.3
-  ## @md | `test.enabled` | true to enable test Jobs and Services | true |
-  enabled: true
+  auth:
+    ## @md | `test.auth.token` | provide a token for auth-related testing | nil |
+    token:
 
 postgres:
   # if enabled we allocate a postgres database here


### PR DESCRIPTION
[CHRON-404](https://blockchaintp.atlassian.net/browse/CHRON-404)
[CHRON-416](https://blockchaintp.atlassian.net/browse/CHRON-416)

Follows [Chronicle PR #360](https://github.com/btpworks/chronicle/pull/360), which includes Chronicle docs updates on "**Helm Testing**".
- [x] merged

# PR Checklist

## Please complete this checklist after opening your PR

* [x] I have updated documentation as necessary
* [x] I have updated helm chart(s) if needed
* [x] I have added tests if needed
* [x] All new and existing tests are passing
* [x] Any breaking changes are clearly flagged and documented
* [x] I’ve included a link to any relevant ticket(s)


[CHRON-404]: https://blockchaintp.atlassian.net/browse/CHRON-404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CHRON-416]: https://blockchaintp.atlassian.net/browse/CHRON-416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ